### PR TITLE
Add remote name option

### DIFF
--- a/dtlpy/repositories/items.py
+++ b/dtlpy/repositories/items.py
@@ -29,7 +29,8 @@ class Items:
                 raise exceptions.PlatformException(
                     error='400',
                     message='Cannot perform action WITHOUT Dataset entity in Items repository. Please set a dataset')
-            self._dataset = self.datasets.get(dataset_id=self._dataset_id, fetch=None)
+            self._dataset = self.datasets.get(
+                dataset_id=self._dataset_id, fetch=None)
         assert isinstance(self._dataset, entities.Dataset)
         return self._dataset
 
@@ -86,7 +87,8 @@ class Items:
         """
         # prepare request
         success, response = self._client_api.gen_request(req_type="POST",
-                                                         path="/datasets/{}/query".format(self.dataset.id),
+                                                         path="/datasets/{}/query".format(
+                                                             self.dataset.id),
                                                          json_req=filters.prepare())
         if not success:
             raise exceptions.PlatformException(response)
@@ -198,7 +200,8 @@ class Items:
                        "withTaskAnnotationsStatus": with_task_annotations_status}
                    }
         success, response = self._client_api.gen_request(req_type="post",
-                                                         path="/items/{}/clone".format(item_id),
+                                                         path="/items/{}/clone".format(
+                                                             item_id),
                                                          json_req=payload)
         # check response
         if success:
@@ -220,7 +223,8 @@ class Items:
         """
         if item_id is not None:
             success, response = self._client_api.gen_request(req_type="delete",
-                                                             path="/items/{}".format(item_id),
+                                                             path="/items/{}".format(
+                                                                 item_id),
                                                              )
         elif filename is not None:
             if not filename.startswith("/"):
@@ -231,7 +235,8 @@ class Items:
             if len(items) == 0:
                 raise exceptions.PlatformException("404", "Item not found")
             elif len(items) > 1:
-                raise exceptions.PlatformException(error="404", message="More the 1 item exist by the name provided")
+                raise exceptions.PlatformException(
+                    error="404", message="More the 1 item exist by the name provided")
             else:
                 item_id = items[0].id
                 success, response = self._client_api.gen_request(req_type="delete",
@@ -239,10 +244,12 @@ class Items:
         elif filters is not None:
             # prepare request
             success, response = self._client_api.gen_request(req_type="POST",
-                                                             path="/datasets/{}/query".format(self.dataset.id),
+                                                             path="/datasets/{}/query".format(
+                                                                 self.dataset.id),
                                                              json_req=filters.prepare(operation='delete'))
         else:
-            raise exceptions.PlatformException("400", "Must provide item id, filename or filters")
+            raise exceptions.PlatformException(
+                "400", "Must provide item id, filename or filters")
 
         # check response
         if success:
@@ -262,14 +269,16 @@ class Items:
         :param system_metadata: bool
         :return: Item object
         """
-        ref = filters is not None and (filters._ref_task or filters._ref_assignment)
+        ref = filters is not None and (
+            filters._ref_task or filters._ref_assignment)
 
         if system_update_values and not system_metadata:
             logger.warning('system metadata will not be updated because param system_metadata is False')
 
         # check params
         if item is None and filters is None:
-            raise exceptions.PlatformException('400', 'must provide either item or filters')
+            raise exceptions.PlatformException(
+                '400', 'must provide either item or filters')
 
         value_to_update = update_values or system_update_values
 
@@ -290,7 +299,8 @@ class Items:
                                                              path=url_path,
                                                              json_req=json_req)
             if success:
-                logger.debug("Item was updated successfully. Item id: {}".format(item.id))
+                logger.debug(
+                    "Item was updated successfully. Item id: {}".format(item.id))
                 return self.items_entity.from_json(client_api=self._client_api,
                                                    _json=response.json(),
                                                    dataset=self._dataset)
@@ -371,6 +381,7 @@ class Items:
             local_annotations_path=None,
             # upload options
             remote_path="/",
+            remote_name=None,
             file_types=None,
             num_workers=32,
             overwrite=False,
@@ -386,6 +397,7 @@ class Items:
         :param local_path: list of local file, local folder, BufferIO, or url to upload
         :param local_annotations_path: path to dataloop format annotations json files.
         :param remote_path: remote path to save.
+        :param remote_name: remote base name to save.
         :param file_types: list of file type to upload. e.g ['.jpg', '.png']. default is all
         :param num_workers:
         :return: Output (list/single item)
@@ -402,6 +414,7 @@ class Items:
             local_annotations_path=local_annotations_path,
             # upload options
             remote_path=remote_path,
+            remote_name=remote_name,
             file_types=file_types,
             # config
             num_workers=num_workers,

--- a/dtlpy/repositories/items.py
+++ b/dtlpy/repositories/items.py
@@ -29,8 +29,7 @@ class Items:
                 raise exceptions.PlatformException(
                     error='400',
                     message='Cannot perform action WITHOUT Dataset entity in Items repository. Please set a dataset')
-            self._dataset = self.datasets.get(
-                dataset_id=self._dataset_id, fetch=None)
+            self._dataset = self.datasets.get(dataset_id=self._dataset_id, fetch=None)
         assert isinstance(self._dataset, entities.Dataset)
         return self._dataset
 
@@ -87,8 +86,7 @@ class Items:
         """
         # prepare request
         success, response = self._client_api.gen_request(req_type="POST",
-                                                         path="/datasets/{}/query".format(
-                                                             self.dataset.id),
+                                                         path="/datasets/{}/query".format(self.dataset.id),
                                                          json_req=filters.prepare())
         if not success:
             raise exceptions.PlatformException(response)
@@ -200,8 +198,7 @@ class Items:
                        "withTaskAnnotationsStatus": with_task_annotations_status}
                    }
         success, response = self._client_api.gen_request(req_type="post",
-                                                         path="/items/{}/clone".format(
-                                                             item_id),
+                                                         path="/items/{}/clone".format(item_id),
                                                          json_req=payload)
         # check response
         if success:
@@ -223,8 +220,7 @@ class Items:
         """
         if item_id is not None:
             success, response = self._client_api.gen_request(req_type="delete",
-                                                             path="/items/{}".format(
-                                                                 item_id),
+                                                             path="/items/{}".format(item_id),
                                                              )
         elif filename is not None:
             if not filename.startswith("/"):
@@ -235,8 +231,7 @@ class Items:
             if len(items) == 0:
                 raise exceptions.PlatformException("404", "Item not found")
             elif len(items) > 1:
-                raise exceptions.PlatformException(
-                    error="404", message="More the 1 item exist by the name provided")
+                raise exceptions.PlatformException(error="404", message="More the 1 item exist by the name provided")
             else:
                 item_id = items[0].id
                 success, response = self._client_api.gen_request(req_type="delete",
@@ -244,12 +239,10 @@ class Items:
         elif filters is not None:
             # prepare request
             success, response = self._client_api.gen_request(req_type="POST",
-                                                             path="/datasets/{}/query".format(
-                                                                 self.dataset.id),
+                                                             path="/datasets/{}/query".format(self.dataset.id),
                                                              json_req=filters.prepare(operation='delete'))
         else:
-            raise exceptions.PlatformException(
-                "400", "Must provide item id, filename or filters")
+            raise exceptions.PlatformException("400", "Must provide item id, filename or filters")
 
         # check response
         if success:
@@ -269,16 +262,14 @@ class Items:
         :param system_metadata: bool
         :return: Item object
         """
-        ref = filters is not None and (
-            filters._ref_task or filters._ref_assignment)
+        ref = filters is not None and (filters._ref_task or filters._ref_assignment)
 
         if system_update_values and not system_metadata:
             logger.warning('system metadata will not be updated because param system_metadata is False')
 
         # check params
         if item is None and filters is None:
-            raise exceptions.PlatformException(
-                '400', 'must provide either item or filters')
+            raise exceptions.PlatformException('400', 'must provide either item or filters')
 
         value_to_update = update_values or system_update_values
 
@@ -299,8 +290,7 @@ class Items:
                                                              path=url_path,
                                                              json_req=json_req)
             if success:
-                logger.debug(
-                    "Item was updated successfully. Item id: {}".format(item.id))
+                logger.debug("Item was updated successfully. Item id: {}".format(item.id))
                 return self.items_entity.from_json(client_api=self._client_api,
                                                    _json=response.json(),
                                                    dataset=self._dataset)

--- a/dtlpy/repositories/uploader.py
+++ b/dtlpy/repositories/uploader.py
@@ -23,11 +23,12 @@ NUM_TRIES = 3  # try to upload 3 time before fail on item
 
 
 class UploadElement:
-    def __init__(self, element_type, buffer, remote_filepath, annotations_filepath, link_dataset_id=None,
+    def __init__(self, element_type, buffer, remote_filepath, annotations_filepath, remote_name=None, link_dataset_id=None,
                  item_metadata=None):
         self.type = element_type
         self.buffer = buffer
         self.remote_filepath = remote_filepath
+        self.remote_name = remote_name
         self.item_metadata = item_metadata
         self.exists_in_remote = False
         self.checked_in_remote = False
@@ -48,6 +49,7 @@ class Uploader:
             local_annotations_path=None,
             # upload options
             remote_path=None,
+            remote_name=None,
             file_types=None,
             num_workers=None,
             overwrite=False,
@@ -62,6 +64,7 @@ class Uploader:
         :param local_path: local file or folder to upload
         :param local_annotations_path: path to dataloop format annotations json files.
         :param remote_path: remote path to save.
+        :param remote_name: remote base name to save.
         :param file_types: list of file type to upload. e.g ['.jpg', '.png']. default is all
         :param num_workers: NOT USED deprecated
         :param item_metadata: upload the items with the metadata dictionary
@@ -82,7 +85,8 @@ class Uploader:
             raise PlatformException(error="400", message=msg)
         if item_metadata is not None:
             if not isinstance(item_metadata, dict):
-                msg = '"item_metadata" should be a metadata dictionary. Got type: {}'.format(type(item_metadata))
+                msg = '"item_metadata" should be a metadata dictionary. Got type: {}'.format(
+                    type(item_metadata))
                 raise PlatformException(error="400", message=msg)
         if num_workers is not None:
             self.items_repository._client_api.num_processes = num_workers
@@ -93,10 +97,16 @@ class Uploader:
         local_annotations_path_list = None
         if not isinstance(local_path, list):
             local_path_list = [local_path]
+            assert isinstance(remote_name, str) or remote_name is None
+            remote_name_list = [remote_name]
             if local_annotations_path is not None:
                 local_annotations_path_list = [local_annotations_path]
         else:
             local_path_list = local_path
+            if remote_name is not None:
+                assert isinstance(remote_name, list)
+                assert len(remote_name) == len(local_path_list)
+                remote_name_list = remote_name
             if local_annotations_path is not None:
                 assert len(local_annotations_path) == len(local_path_list)
                 local_annotations_path_list = local_annotations_path
@@ -104,9 +114,20 @@ class Uploader:
         if local_annotations_path is None:
             local_annotations_path_list = [None] * len(local_path_list)
 
+        for local_path, remote_name, local_annotation_path in zip(local_path_list, remote_name_list, local_annotations_path_list):
+            if local_annotation_path is not None:
+                if remote_name is not None:
+                    remote_name_noext  = os.path.splitext(remote_name)[0]
+                    annotation_name_noext = os.path.splitext(os.path.basename(local_annotation_path))[0]
+                    assert remote_name_noext == annotation_name_noext
+                else:
+                    # TODO: check whether local_path has same file name (sauf extension) as local_annotation_path
+                    pass
+
         elements = list()
         total_size = 0
-        for upload_item_element, upload_annotations_element in zip(local_path_list, local_annotations_path_list):
+        for upload_item_element, remote_name, upload_annotations_element in zip(local_path_list, remote_name_list,
+                                                                                local_annotations_path_list):
             if isinstance(upload_item_element, str):
                 with_head_folder = True
                 if upload_item_element.endswith('*'):
@@ -119,7 +140,8 @@ class Uploader:
                         for filename in files:
                             _, ext = os.path.splitext(filename)
                             if file_types is None or ext in file_types:
-                                filepath = os.path.join(root, filename)  # get full image filepath
+                                # get full image filepath
+                                filepath = os.path.join(root, filename)
                                 # extract item's size
                                 total_size += os.path.getsize(filepath)
                                 # get annotations file
@@ -128,7 +150,8 @@ class Uploader:
                                     annotations_filepath = filepath.replace(upload_item_element,
                                                                             upload_annotations_element)
                                     # remove image extension
-                                    annotations_filepath, _ = os.path.splitext(annotations_filepath)
+                                    annotations_filepath, _ = os.path.splitext(
+                                        annotations_filepath)
                                     # add json extension
                                     annotations_filepath += ".json"
                                 else:
@@ -137,10 +160,13 @@ class Uploader:
                                     remote_filepath = remote_path + os.path.relpath(filepath, os.path.dirname(
                                         upload_item_element))
                                 else:
-                                    remote_filepath = remote_path + os.path.relpath(filepath, upload_item_element)
+                                    remote_filepath = remote_path + \
+                                        os.path.relpath(
+                                            filepath, upload_item_element)
                                 element = UploadElement(element_type='file',
                                                         buffer=filepath,
-                                                        remote_filepath=remote_filepath.replace("\\", "/"),
+                                                        remote_filepath=remote_filepath.replace(
+                                                            "\\", "/"),
                                                         annotations_filepath=annotations_filepath,
                                                         item_metadata=item_metadata)
                                 elements.append(element)
@@ -150,6 +176,9 @@ class Uploader:
                     filepath = upload_item_element
                     # extract item's size
                     total_size += os.path.getsize(filepath)
+                    # determine item's remote base name
+                    if remote_name is None:
+                        remote_name = os.path.basename(filepath)
                     # get annotations file
                     if upload_annotations_element is not None:
                         # change path to annotations
@@ -161,7 +190,7 @@ class Uploader:
                     else:
                         annotations_filepath = None
                     # append to list
-                    remote_filepath = remote_path + os.path.basename(filepath)
+                    remote_filepath = remote_path + remote_name
                     element = UploadElement(element_type='file',
                                             buffer=filepath,
                                             remote_filepath=remote_filepath,
@@ -170,7 +199,10 @@ class Uploader:
                     elements.append(element)
                 elif self.is_url(upload_item_element):
                     # noinspection PyTypeChecker
-                    remote_filepath = remote_path + upload_item_element.split('/')[-1]
+                    if remote_name is None:
+                        remote_name = upload_item_element.split('/')[-1]
+                    remote_filepath = remote_path + remote_name
+
                     element = UploadElement(element_type='url',
                                             buffer=upload_item_element,
                                             remote_filepath=remote_filepath,
@@ -178,11 +210,14 @@ class Uploader:
                                             item_metadata=item_metadata)
                     elements.append(element)
                 else:
-                    raise PlatformException("404", "Unknown local path: {}".format(local_path))
+                    raise PlatformException(
+                        "404", "Unknown local path: {}".format(local_path))
             elif isinstance(upload_item_element, entities.Item):
                 link = entities.Link(ref=upload_item_element.id, type='id', dataset_id=upload_item_element.datasetId,
                                      name='{}_link.json'.format(upload_item_element.name))
-                remote_filepath = '{}{}'.format(remote_path, link.name)
+                if remote_name is None:
+                    remote_name = link.name
+                remote_filepath = '{}{}'.format(remote_path, remote_name)
 
                 element = UploadElement(element_type='link',
                                         buffer=link,
@@ -191,7 +226,8 @@ class Uploader:
                                         item_metadata=item_metadata)
                 elements.append(element)
             elif isinstance(upload_item_element, entities.Link):
-                remote_filepath = '{}{}_link.json'.format(remote_path, upload_item_element.name)
+                remote_filepath = '{}{}_link.json'.format(
+                    remote_path, upload_item_element.name)
 
                 element = UploadElement(element_type='link',
                                         buffer=upload_item_element,
@@ -235,7 +271,9 @@ class Uploader:
                         error="400",
                         message='Upload elemnet type was bytes. Must put attribute "name" on buffer (with file name) '
                                 'when uploading buffers')
-                remote_filepath = remote_path + upload_item_element.name
+                if remote_name is None:
+                    remote_name = upload_item_element.name
+                remote_filepath = remote_path + remote_name
                 element = UploadElement(element_type='buffer',
                                         buffer=upload_item_element,
                                         remote_filepath=remote_filepath,
@@ -266,12 +304,14 @@ class Uploader:
         pbar = tqdm.tqdm(total=num_files, disable=disable_pbar)
 
         def exception_handler(loop, context):
-            logger.debug("[Asyc] Upload item caught the following exception: {}".format(context['message']))
+            logger.debug("[Asyc] Upload item caught the following exception: {}".format(
+                context['message']))
 
         loop = asyncio.new_event_loop()
         loop.set_exception_handler(exception_handler)
         asyncio.set_event_loop(loop)
-        asyncio_semaphore = asyncio.BoundedSemaphore(8 * self.items_repository._client_api._num_processes)
+        asyncio_semaphore = asyncio.BoundedSemaphore(
+            8 * self.items_repository._client_api._num_processes)
         for i_item in range(num_files):
             element = elements[i_item]
             # upload
@@ -295,7 +335,8 @@ class Uploader:
             logger.info("Number of files {}: {}".format(action, n_for_action))
 
         # log error
-        errors_list = [errors[i_job] for i_job, suc in enumerate(success) if suc is False]
+        errors_list = [errors[i_job]
+                       for i_job, suc in enumerate(success) if suc is False]
         if len(errors_list) > 0:
             log_filepath = os.path.join(os.getcwd(),
                                         "log_{}.txt".format(datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")))
@@ -306,7 +347,8 @@ class Uploader:
                 n_error=len(errors_list), log_filepath=log_filepath))
 
         # remove empty cells
-        output = [output[i_job] for i_job, suc in enumerate(success) if suc is True]
+        output = [output[i_job]
+                  for i_job, suc in enumerate(success) if suc is True]
         if len(output) == 1:
             output = output[0]
 
@@ -335,7 +377,8 @@ class Uploader:
             for remote_path in item_remote_paths:
                 if not remote_path.endswith('/'):
                     remote_path += '/'
-                filters.add(field='filename', values={'$glob': remote_path + '*'})
+                filters.add(field='filename', values={
+                            '$glob': remote_path + '*'})
             filters.method = 'or'
             pages = self.items_repository.list(filters=filters)
 
@@ -355,7 +398,8 @@ class Uploader:
                     remote_existence_dict[item_remote_filepath] = None
 
         except Exception:
-            logger.error('{}\nCant create existence dictionary when uploading'.format(traceback.format_exc()))
+            logger.error('{}\nCant create existence dictionary when uploading'.format(
+                traceback.format_exc()))
 
     async def __single_async_upload(self,
                                     filepath,
@@ -381,7 +425,8 @@ class Uploader:
         if isinstance(filepath, str):
             # upload local file
             if not os.path.isfile(filepath):
-                raise PlatformException(error="404", message="Filepath doesnt exists. file: {}".format(filepath))
+                raise PlatformException(
+                    error="404", message="Filepath doesnt exists. file: {}".format(filepath))
             if uploaded_filename is None:
                 uploaded_filename = os.path.basename(filepath)
             if os.path.isfile(filepath):
@@ -415,7 +460,8 @@ class Uploader:
             item_size = to_upload.seek(0, 2)
             to_upload.seek(0)
             item_type = 'file'
-        remote_url = "/datasets/{}/items".format(self.items_repository.dataset.id)
+        remote_url = "/datasets/{}/items".format(
+            self.items_repository.dataset.id)
         try:
             response = await self.items_repository._client_api.upload_file_async(to_upload=to_upload,
                                                                                  item_type=item_type,
@@ -438,9 +484,11 @@ class Uploader:
                                                                 dataset=self.items_repository.dataset)
             if annotations is not None:
                 try:
-                    self.__upload_annotations(annotations=annotations, item=item)
+                    self.__upload_annotations(
+                        annotations=annotations, item=item)
                 except Exception:
-                    logger.exception('Error uploading annotations to item id: {}'.format(item.id))
+                    logger.exception(
+                        'Error uploading annotations to item id: {}'.format(item.id))
         else:
             raise PlatformException(response)
         return item, response.headers.get('x-item-op', 'na')
@@ -455,10 +503,12 @@ class Uploader:
             saved_locally = False
             temp_dir = None
             action = 'na'
-            remote_folder, remote_filename = os.path.split(element.remote_filepath)
+            remote_folder, remote_name = os.path.split(
+                element.remote_filepath)
 
             if element.type == 'url':
-                saved_locally, element.buffer, temp_dir = self.url_to_data(element.buffer)
+                saved_locally, element.buffer, temp_dir = self.url_to_data(
+                    element.buffer)
             elif element.type == 'link':
                 element.buffer = self.link(ref=element.buffer.ref, dataset_id=element.buffer.dataset_id,
                                            type=element.buffer.type, mimetype=element.buffer.mimetype)
@@ -467,7 +517,7 @@ class Uploader:
 
             for i_try in range(NUM_TRIES):
                 try:
-                    logger.debug("Upload item: {path}. Try {i}/{n}. Starting..".format(path=remote_filename,
+                    logger.debug("Upload item: {path}. Try {i}/{n}. Starting..".format(path=remote_name,
                                                                                        i=i_try + 1,
                                                                                        n=NUM_TRIES))
                     item, action = await self.__single_async_upload(filepath=element.buffer,
@@ -475,10 +525,11 @@ class Uploader:
                                                                     item_metadata=element.item_metadata,
                                                                     annotations=element.annotations_filepath,
                                                                     remote_path=remote_folder,
-                                                                    uploaded_filename=remote_filename,
-                                                                    last_try=(i_try + 1) == NUM_TRIES,
+                                                                    uploaded_filename=remote_name,
+                                                                    last_try=(
+                                                                        i_try + 1) == NUM_TRIES,
                                                                     callback=None)
-                    logger.debug("Upload item: {path}. Try {i}/{n}. Success. Item id: {id}".format(path=remote_filename,
+                    logger.debug("Upload item: {path}. Try {i}/{n}. Success. Item id: {id}".format(path=remote_name,
                                                                                                    i=i_try + 1,
                                                                                                    n=NUM_TRIES,
                                                                                                    id=item.id))
@@ -486,7 +537,7 @@ class Uploader:
                         break
                     time.sleep(0.3 * (2 ** (NUM_TRIES - 1)))
                 except Exception as e:
-                    logger.debug("Upload item: {path}. Try {i}/{n}. Fail.".format(path=remote_filename,
+                    logger.debug("Upload item: {path}. Try {i}/{n}. Fail.".format(path=remote_name,
                                                                                   i=i_try + 1,
                                                                                   n=NUM_TRIES))
                     err = e
@@ -500,7 +551,7 @@ class Uploader:
                 success[i_item] = True
             else:
                 status[i_item] = "error"
-                output[i_item] = remote_folder + remote_filename
+                output[i_item] = remote_folder + remote_name
                 success[i_item] = False
                 errors[i_item] = "{}\n{}".format(err, trace)
             pbar.update()
@@ -524,7 +575,8 @@ class Uploader:
                 raise PlatformException(
                     error="400",
                     message='MISSING "annotations" in annotations file, cant upload. item_id: {}, '
-                            "annotations_filepath: {}".format(item.id, annotations),
+                            "annotations_filepath: {}".format(
+                                item.id, annotations),
                 )
             item.annotations.upload(annotations=annotations)
 

--- a/dtlpy/repositories/uploader.py
+++ b/dtlpy/repositories/uploader.py
@@ -140,8 +140,7 @@ class Uploader:
                         for filename in files:
                             _, ext = os.path.splitext(filename)
                             if file_types is None or ext in file_types:
-                                # get full image filepath
-                                filepath = os.path.join(root, filename)
+                                filepath = os.path.join(root, filename)  # get full image filepath
                                 # extract item's size
                                 total_size += os.path.getsize(filepath)
                                 # get annotations file
@@ -150,8 +149,7 @@ class Uploader:
                                     annotations_filepath = filepath.replace(upload_item_element,
                                                                             upload_annotations_element)
                                     # remove image extension
-                                    annotations_filepath, _ = os.path.splitext(
-                                        annotations_filepath)
+                                    annotations_filepath, _ = os.path.splitext(annotations_filepath)
                                     # add json extension
                                     annotations_filepath += ".json"
                                 else:

--- a/tests/features/items_repo/test_items_upload.feature
+++ b/tests/features/items_repo/test_items_upload.feature
@@ -20,9 +20,26 @@ Feature: Items repository upload service testing
         And Item object from host equals item uploaded
         And Item in host when downloaded to "test_items_upload_downloaded_item" equals item in "assets_split/items_upload/0000000162.jpg"
     
+    Scenario: Upload a single item with a specific remote name set via the buffer interface
+        When I upload the file in path "assets_split/items_upload/0000000162.jpg" with remote name "file.jpg" set via the buffer interface
+        Then Item exist in host
+        And Item in host has name "file.jpg"
+        And Upload method returned an Item object
+        And Item object from host equals item uploaded
+        And Item in host when downloaded to "test_items_upload_downloaded_item" equals item in "assets_split/items_upload/0000000162.jpg"
+
     Scenario: Upload a single item with a specific remote name
         When I upload the file in path "assets_split/items_upload/0000000162.jpg" with remote name "file.jpg"
         Then Item exist in host
+        And Item in host has name "file.jpg"
+        And Upload method returned an Item object
+        And Item object from host equals item uploaded
+        And Item in host when downloaded to "test_items_upload_downloaded_item" equals item in "assets_split/items_upload/0000000162.jpg"
+
+    Scenario: Upload a single item with a specific remote name to a specific remote path
+        When I upload the file in path "assets_split/items_upload/0000000162.jpg" with remote name "file.jpg" to remote path "/folder"
+        Then Item exist in host
+        And Item in host is in folder "/folder"
         And Item in host has name "file.jpg"
         And Upload method returned an Item object
         And Item object from host equals item uploaded
@@ -61,6 +78,23 @@ Feature: Items repository upload service testing
         And I delete all items from host
         When I upload items from buffer to host
         Then There are "3" items in host
+
+    Scenario: Upload item from buffer with specific remote name
+        When I use a buffer to upload the file in path "assets_split/items_upload/0000000162.jpg" with remote name "file.jpg"
+        Then Item exist in host
+        And Item in host has name "file.jpg"
+        And Upload method returned an Item object
+        And Item object from host equals item uploaded
+        And Item in host when downloaded to "test_items_upload_downloaded_item" equals item in "assets_split/items_upload/0000000162.jpg"
+
+    # TODO
+    # Scenario: Upload item from URL with specific remote name
+    #     When I upload a file from a URL "http://some.domain/some_file.png" with remote name "file.png"
+    #     Then Item exist in host
+    #     And Item in host has name "file.jpg"
+    #     And Upload method returned an Item object
+    #     And Item object from host equals item uploaded
+    #     And Item in host when downloaded to "test_items_upload_downloaded_item" equals item available at "http://some.domain/some_file.png"
 
     Scenario: Upload a single item - video
         When I upload a file in path "sample_video.mp4"

--- a/tests/features/steps/items_repo/test_items_upload.py
+++ b/tests/features/steps/items_repo/test_items_upload.py
@@ -7,9 +7,7 @@ import shutil
 
 @behave.when(u'I upload a file in path "{item_local_path}"')
 def step_impl(context, item_local_path):
-    item_local_path = os.path.join(
-
-        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    item_local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
     context.item = context.dataset.items.upload(local_path=item_local_path,
                                                 remote_path=None
                                                 )
@@ -21,8 +19,7 @@ def step_impl(context, item_local_path, option):
         overwrite = True
     else:
         overwrite = False
-    item_local_path = os.path.join(
-        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    item_local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
     context.item = context.dataset.items.upload(local_path=item_local_path,
                                                 remote_path=None,
                                                 overwrite=overwrite
@@ -31,8 +28,7 @@ def step_impl(context, item_local_path, option):
 
 @behave.when(u'I upload file in path "{item_local_path}" to remote path "{remote_path}"')
 def step_impl(context, item_local_path, remote_path):
-    item_local_path = os.path.join(
-        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    item_local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
     context.item = context.dataset.items.upload(local_path=item_local_path,
                                                 remote_path=remote_path)
 
@@ -53,10 +49,8 @@ def step_impl(context):
 
 @behave.then(u'Item in host when downloaded to "{download_path}" equals item in "{item_local_path}"')
 def step_impl(context, item_local_path, download_path):
-    download_path = os.path.join(
-        os.environ["DATALOOP_TEST_ASSETS"], download_path)
-    file_to_compare = os.path.join(
-        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    download_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], download_path)
+    file_to_compare = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
 
     context.dataset.items.download(
         filters=None,
@@ -98,8 +92,7 @@ def step_impl(context):
 
 @behave.then(u'Item in host is in folder "{remote_path}"')
 def step_impl(context, remote_path):
-    assert remote_path in context.dataset.items.get(
-        item_id=context.item.id).filename
+    assert remote_path in context.dataset.items.get(item_id=context.item.id).filename
 
 
 @behave.when(u'I upload the file in path "{local_path}", opened as a buffer, with remote name "{remote_name}"')
@@ -151,8 +144,7 @@ def step_impl(context, local_path, remote_path, remote_name):
 
 @behave.then(u'Item in host has name "{remote_name}"')
 def step_impl(context, remote_name):
-    assert remote_name in context.dataset.items.get(
-        item_id=context.item.id).filename
+    assert remote_name in context.dataset.items.get(item_id=context.item.id).filename
 
 
 @behave.then(u"Item was merged to host")
@@ -169,14 +161,12 @@ def step_impl(context):
 def step_impl(context, local_path, illegal_remote_path):
     local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], local_path)
     # count error logs before
-    context.error_logs_before = sum(
-        [1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
+    context.error_logs_before = sum([1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
     # upload
     context.item = context.dataset.items.upload(local_path=local_path,
                                                 remote_path=illegal_remote_path)
     # count error logs after
-    context.error_logs_after = sum(
-        [1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
+    context.error_logs_after = sum([1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
 
 
 @behave.when(u'I try to upload file in path "{illegal_local_path}"')

--- a/tests/features/steps/items_repo/test_items_upload.py
+++ b/tests/features/steps/items_repo/test_items_upload.py
@@ -7,7 +7,9 @@ import shutil
 
 @behave.when(u'I upload a file in path "{item_local_path}"')
 def step_impl(context, item_local_path):
-    item_local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    item_local_path = os.path.join(
+
+        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
     context.item = context.dataset.items.upload(local_path=item_local_path,
                                                 remote_path=None
                                                 )
@@ -19,7 +21,8 @@ def step_impl(context, item_local_path, option):
         overwrite = True
     else:
         overwrite = False
-    item_local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    item_local_path = os.path.join(
+        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
     context.item = context.dataset.items.upload(local_path=item_local_path,
                                                 remote_path=None,
                                                 overwrite=overwrite
@@ -28,7 +31,8 @@ def step_impl(context, item_local_path, option):
 
 @behave.when(u'I upload file in path "{item_local_path}" to remote path "{remote_path}"')
 def step_impl(context, item_local_path, remote_path):
-    item_local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    item_local_path = os.path.join(
+        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
     context.item = context.dataset.items.upload(local_path=item_local_path,
                                                 remote_path=remote_path)
 
@@ -49,8 +53,10 @@ def step_impl(context):
 
 @behave.then(u'Item in host when downloaded to "{download_path}" equals item in "{item_local_path}"')
 def step_impl(context, item_local_path, download_path):
-    download_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], download_path)
-    file_to_compare = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
+    download_path = os.path.join(
+        os.environ["DATALOOP_TEST_ASSETS"], download_path)
+    file_to_compare = os.path.join(
+        os.environ["DATALOOP_TEST_ASSETS"], item_local_path)
 
     context.dataset.items.download(
         filters=None,
@@ -92,27 +98,61 @@ def step_impl(context):
 
 @behave.then(u'Item in host is in folder "{remote_path}"')
 def step_impl(context, remote_path):
-    assert remote_path in context.dataset.items.get(item_id=context.item.id).filename
+    assert remote_path in context.dataset.items.get(
+        item_id=context.item.id).filename
 
 
-@behave.when(u'I upload the file in path "{local_path}" with remote name "{remote_filename}"')
-def step_impl(context, local_path, remote_filename):
+@behave.when(u'I upload the file in path "{local_path}", opened as a buffer, with remote name "{remote_name}"')
+def step_impl(context, local_path, remote_name):
     local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], local_path)
 
     import io
 
     with open(local_path, "rb") as f:
         buffer = io.BytesIO(f.read())
-        buffer.name = remote_filename
+    
+    context.item = context.dataset.items.upload(
+        local_path=buffer, remote_path=None, remote_name=remote_name
+    )
+
+    
+@behave.when(u'I upload the file in path "{local_path}" with remote name "{remote_name}" set via the buffer interface')
+def step_impl(context, local_path, remote_name):
+    local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], local_path)
+
+    import io
+
+    with open(local_path, "rb") as f:
+        buffer = io.BytesIO(f.read())
+        buffer.name = remote_name
 
     context.item = context.dataset.items.upload(
         local_path=buffer, remote_path=None
     )
 
 
+@behave.when(u'I upload the file in path "{local_path}" with remote name "{remote_name}"')
+def step_impl(context, local_path, remote_name):
+    local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], local_path)
+
+    context.item = context.dataset.items.upload(
+        local_path=local_path, remote_path=None, remote_name=remote_name
+    )
+
+
+@behave.when(u'I upload the file in path "{local_path}" with remote name "{remote_name}" to remote path "{remote_path}"')
+def step_impl(context, local_path, remote_path, remote_name):
+    local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], local_path)
+
+    context.item = context.dataset.items.upload(
+        local_path=local_path, remote_path=remote_path, remote_name=remote_name
+    )
+
+
 @behave.then(u'Item in host has name "{remote_name}"')
 def step_impl(context, remote_name):
-    assert remote_name in context.dataset.items.get(item_id=context.item.id).filename
+    assert remote_name in context.dataset.items.get(
+        item_id=context.item.id).filename
 
 
 @behave.then(u"Item was merged to host")
@@ -129,12 +169,14 @@ def step_impl(context):
 def step_impl(context, local_path, illegal_remote_path):
     local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], local_path)
     # count error logs before
-    context.error_logs_before = sum([1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
+    context.error_logs_before = sum(
+        [1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
     # upload
     context.item = context.dataset.items.upload(local_path=local_path,
                                                 remote_path=illegal_remote_path)
     # count error logs after
-    context.error_logs_after = sum([1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
+    context.error_logs_after = sum(
+        [1 for filename in os.listdir(os.getcwd()) if filename.startswith("log_")])
 
 
 @behave.when(u'I try to upload file in path "{illegal_local_path}"')
@@ -192,4 +234,17 @@ def step_impl(context, item_count):
     filters = context.dl.Filters()
     filters.add(field='type', values='file')
     context.item_list = context.dataset.items.list(filters=filters)
-    assert len(context.item_list.items) == int(item_count) == context.items_uploaded
+    assert len(context.item_list.items) == int(
+        item_count) == context.items_uploaded
+
+
+@behave.when(u'I use a buffer to upload the file in path "{local_path}" with remote name "{remote_name}"')
+def step_impl(context, local_path, remote_name):
+    local_path = os.path.join(os.environ["DATALOOP_TEST_ASSETS"], local_path)
+
+    import io
+
+    with open(local_path, "rb") as f:
+        buffer = io.BytesIO(f.read())
+        context.dataset.items.upload(
+            local_path=buffer, remote_name=remote_name)


### PR DESCRIPTION
This PR addresses #3 by giving `repositories.uploader.Uploader.upload()` (and `repositories.items.upload()`) an additional argument `remote_name`, which, analogously to `local_path` and `local_annotations_path`, can be one of three types:
- `None`: as before, the remote file name(s) is set to be the same as the file name(s) in `local_path`
- `str` / `list` of `str`: the remote file name(s) are set to the the content of `remote_name`

For now, it's only a draft:
- while the changes seem to work, I could not figure out how to run the tests (which I will open an issue about), so I don't know whether they will pass
- I don't know how to best test the changes when uploading an item from a URL. This is not tested on `master` either
- I am not clear about how to update the documentation in `docs/` (if I have to, that is; it looks incomplete to me, but I have very little experience with Sphinx and Autodoc)

Any suggestions for improvements are highly welcome!