### PR TITLE
Fix var->str typo which produces warning on import

### DIFF
--- a/dtlpy/entities/package.py
+++ b/dtlpy/entities/package.py
@@ -170,7 +170,7 @@ class Package(entities.DlEntity):
             slots = [entities.PackageSlot.from_json(_slot) for _slot in slots]
 
         codebase = _json.get('codebase', None)
-        if 'codebase' is not None:
+        if codebase is not None:
             codebase = entities.Codebase.from_json(_json=codebase, client_api=client_api)
 
         requirements = _json.get('requirements', None)


### PR DESCRIPTION
There is a typo in `package.py` which checks the literal `'codebase'` rather than the variable. In addition to an import warning, this presumably leads to incorrect behavior in the case that `codebase` is `None`